### PR TITLE
Disable Jekyll for GitHub Pages

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll on GitHub Pages so underscore-prefixed Quarto resources are served.

--- a/Documentation/Website/outputs.qmd
+++ b/Documentation/Website/outputs.qmd
@@ -28,12 +28,12 @@ The PDF backup contains static figures only.
 Use the standalone HTML deck for animated figures.
 :::
 
-- [Open standalone HTML](/Documentation/Presentations/IAVS_2026/_output/index.html)
-- [Download PDF](/Documentation/Presentations/IAVS_2026/_output/iavs_2026_presentation.pdf)
+- [Open standalone HTML](../Presentations/IAVS_2026/_output/index.html)
+- [Download PDF](../Presentations/IAVS_2026/_output/iavs_2026_presentation.pdf)
 - [View Quarto source](https://github.com/OndrejMottl/BIODYNAMICS-vegetation-cooccurrence/blob/main/Documentation/Presentations/IAVS_2026/index.qmd)
 
 <iframe
-  src="/Documentation/Presentations/IAVS_2026/_output/index.html"
+  src="../Presentations/IAVS_2026/_output/index.html"
   width="100%"
   height="650px"
   style="border:none;">
@@ -47,7 +47,7 @@ They are intended as reproducibility and maintenance aids rather than result sum
 ### Paleo Temporal - Europe
 
 <iframe
-  src="/Documentation/Progress/paleo_temporal_europe/pipeline_paleo_temporal/project_status_small.html"
+  src="../Progress/paleo_temporal_europe/pipeline_paleo_temporal/project_status_small.html"
   width="100%"
   height="550px"
   style="border:none;">
@@ -56,7 +56,7 @@ They are intended as reproducibility and maintenance aids rather than result sum
 ### Paleo Spatial Resolution - Europe Continental
 
 <iframe
-  src="/Documentation/Progress/paleo_spatial_continental/europe/pipeline_paleo_spatial_resolution/project_status_small.html"
+  src="../Progress/paleo_spatial_continental/europe/pipeline_paleo_spatial_resolution/project_status_small.html"
   width="100%"
   height="550px"
   style="border:none;">
@@ -65,7 +65,7 @@ They are intended as reproducibility and maintenance aids rather than result sum
 ### Modern Spatial Resolution - Europe Continental
 
 <iframe
-  src="/Documentation/Progress/modern_spatial_continental/europe/pipeline_modern_spatial_resolution/project_status_small.html"
+  src="../Progress/modern_spatial_continental/europe/pipeline_modern_spatial_resolution/project_status_small.html"
   width="100%"
   height="550px"
   style="border:none;">
@@ -74,7 +74,7 @@ They are intended as reproducibility and maintenance aids rather than result sum
 ### Traits Reference
 
 <iframe
-  src="/Documentation/Progress/traits_reference/pipeline_traits_reference/project_status_small.html"
+  src="../Progress/traits_reference/pipeline_traits_reference/project_status_small.html"
   width="100%"
   height="550px"
   style="border:none;">

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -2,6 +2,7 @@ project:
   type: website
   output-dir: docs
   resources:
+    - .nojekyll
     - Documentation/Progress/
     - Documentation/Functions_test_coverage/
     - Documentation/Presentations/IAVS_2026/_output/

--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+# Disable Jekyll on GitHub Pages so underscore-prefixed Quarto resources are served.

--- a/docs/Documentation/Website/outputs.html
+++ b/docs/Documentation/Website/outputs.html
@@ -1525,11 +1525,11 @@ Warning
 </div>
 </div>
 <ul>
-<li><a href="../..\Documentation/Presentations/IAVS_2026/_output/index.html">Open standalone HTML</a></li>
-<li><a href="../..\Documentation/Presentations/IAVS_2026/_output/iavs_2026_presentation.pdf">Download PDF</a></li>
+<li><a href="../Presentations/IAVS_2026/_output/index.html">Open standalone HTML</a></li>
+<li><a href="../Presentations/IAVS_2026/_output/iavs_2026_presentation.pdf">Download PDF</a></li>
 <li><a href="https://github.com/OndrejMottl/BIODYNAMICS-vegetation-cooccurrence/blob/main/Documentation/Presentations/IAVS_2026/index.qmd">View Quarto source</a></li>
 </ul>
-<iframe src="../../Documentation/Presentations/IAVS_2026/_output/index.html" width="100%" height="650px" style="border:none;">
+<iframe src="../Presentations/IAVS_2026/_output/index.html" width="100%" height="650px" style="border:none;">
 </iframe>
 </section>
 </section>
@@ -1538,22 +1538,22 @@ Warning
 <p>The pipeline graphs below are generated from <code>{targets}</code> stores and show current build state for selected workflows. They are intended as reproducibility and maintenance aids rather than result summaries.</p>
 <section id="paleo-temporal---europe" class="level3">
 <h3 class="anchored" data-anchor-id="paleo-temporal---europe">Paleo Temporal - Europe</h3>
-<iframe src="../../Documentation/Progress/paleo_temporal_europe/pipeline_paleo_temporal/project_status_small.html" width="100%" height="550px" style="border:none;">
+<iframe src="../Progress/paleo_temporal_europe/pipeline_paleo_temporal/project_status_small.html" width="100%" height="550px" style="border:none;">
 </iframe>
 </section>
 <section id="paleo-spatial-resolution---europe-continental" class="level3">
 <h3 class="anchored" data-anchor-id="paleo-spatial-resolution---europe-continental">Paleo Spatial Resolution - Europe Continental</h3>
-<iframe src="../../Documentation/Progress/paleo_spatial_continental/europe/pipeline_paleo_spatial_resolution/project_status_small.html" width="100%" height="550px" style="border:none;">
+<iframe src="../Progress/paleo_spatial_continental/europe/pipeline_paleo_spatial_resolution/project_status_small.html" width="100%" height="550px" style="border:none;">
 </iframe>
 </section>
 <section id="modern-spatial-resolution---europe-continental" class="level3">
 <h3 class="anchored" data-anchor-id="modern-spatial-resolution---europe-continental">Modern Spatial Resolution - Europe Continental</h3>
-<iframe src="../../Documentation/Progress/modern_spatial_continental/europe/pipeline_modern_spatial_resolution/project_status_small.html" width="100%" height="550px" style="border:none;">
+<iframe src="../Progress/modern_spatial_continental/europe/pipeline_modern_spatial_resolution/project_status_small.html" width="100%" height="550px" style="border:none;">
 </iframe>
 </section>
 <section id="traits-reference" class="level3">
 <h3 class="anchored" data-anchor-id="traits-reference">Traits Reference</h3>
-<iframe src="../../Documentation/Progress/traits_reference/pipeline_traits_reference/project_status_small.html" width="100%" height="550px" style="border:none;">
+<iframe src="../Progress/traits_reference/pipeline_traits_reference/project_status_small.html" width="100%" height="550px" style="border:none;">
 </iframe>
 
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,11 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/outputs.html</loc>
-    <lastmod>2026-06-19T07:00:00.477Z</lastmod>
+    <lastmod>2026-06-19T10:38:26.415Z</lastmod>
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/about.html</loc>
-    <lastmod>2026-06-19T08:18:32.877Z</lastmod>
+    <lastmod>2026-06-19T09:36:26.908Z</lastmod>
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/Documentation/Functions/write_oracle_generated_scss.html</loc>
@@ -438,7 +438,7 @@
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/index.html</loc>
-    <lastmod>2026-06-19T06:44:18.800Z</lastmod>
+    <lastmod>2026-06-19T09:36:27.350Z</lastmod>
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/Documentation/Functions/add_age_to_samples.html</loc>
@@ -866,10 +866,10 @@
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/Documentation/documentation.html</loc>
-    <lastmod>2026-06-19T06:44:27.281Z</lastmod>
+    <lastmod>2026-06-19T09:36:26.908Z</lastmod>
   </url>
   <url>
     <loc>https://ondrejmottl.github.io/BIODYNAMICS-vegetation-cooccurrence/Documentation/Website/installation.html</loc>
-    <lastmod>2026-06-19T06:44:23.130Z</lastmod>
+    <lastmod>2026-06-19T09:36:26.908Z</lastmod>
   </url>
 </urlset>


### PR DESCRIPTION
Add a `.nojekyll` file to prevent Jekyll from processing underscore-prefixed Quarto resources, ensuring they are served correctly on GitHub Pages. Update links to reflect the correct relative paths.