### PR TITLE
Track functional-type inputs across target stores

### DIFF
--- a/Documentation/Implementation_plans/plan_issue170_functional_type_classification_drift_2026-08-12.md
+++ b/Documentation/Implementation_plans/plan_issue170_functional_type_classification_drift_2026-08-12.md
@@ -1,0 +1,95 @@
+# Issue #170 — Functional-type classification reproducibility and provenance
+
+**Date:** 2026-08-12
+**Status:** In progress
+
+## Goal
+
+Explain the regenerated functional-type classification differences, make cross-store trait inputs invalidate downstream spatial pipelines when their scientific content changes, and provide deterministic provenance and comparison evidence for an explicit scientific decision on the updated modern classification.
+
+## Established baseline
+
+- The retained May 16 modern artifact contains 563 taxa and eight functional types.
+- The retained August 7 Issue #156 store reproduces the May artifact exactly.
+- Running the current clustering code on the August 7 inputs also reproduces the May artifact exactly: eight groups, zero assignment differences, and zero silhouette-width differences.
+- The August 12 smoke store contains 565 taxa and selects seven functional types. Among the 563 shared taxa, 21 raw assignments change and 9,330 taxon pairs change their co-clustering relationship.
+- The corrected trait-record target is identical between the August 7 and August 12 stores. The first changed scientific input is the trait taxonomy table, which expands from 7,985 to 8,004 rows.
+- Eleven of the 19 added taxonomy rows were intentionally added to `Data/Input/aux_classification_table.csv` on May 22. Eight additional species were resolved by refreshed automatic taxonomic-classification branches.
+- The expanded taxonomy adds `Apera` and `Hydrocharis` to the modern trait matrix and changes aggregated trait values for `Alisma`, `Impatiens`, `Oxalis`, `Poaceae`, and `Veronica`.
+- The spatial pipeline continued using its cached May cross-store import until Issue #141 invalidated the importing target. This reveals missing dependency tracking at the external trait-store boundary rather than nondeterministic clustering behavior.
+- The retained August 7 paleo store also reproduces the May artifact exactly. The current taxonomy expansion changes the aggregated trait vector only for `Ericales`; the taxon universe, 23-group selection, and assignments remain identical, while the changed distances produce 20 small silhouette differences with maximum absolute delta `0.003114496`.
+
+## Scope
+
+### In scope
+
+- Strict fingerprints for scientific targets imported from external `{targets}` stores.
+- Explicit invalidation of functional-type inputs when the shared trait store changes.
+- Provenance for taxonomy, trait records, aligned trait matrices, clustering configuration, selected group counts, classification payloads, package versions, and retained stores.
+- Partition-aware comparison that distinguishes arbitrary labels from genuine co-clustering changes.
+- Deterministic replay tests with identical inputs and controlled taxon ordering.
+- Scientific comparison of the May and updated modern classifications.
+- A documented decision to retain the May reference or approve a provenance-complete regenerated replacement.
+
+### Out of scope
+
+- Changing the Gower distance, average-linkage clustering, silhouette criterion, downstream viability rule, or functional-type interpretation without separate scientific approval.
+- Publishing regenerated classification files before scientific review.
+- Rerunning all downstream scientific models; that work belongs to #171 after #140 closes.
+
+## Implementation checkpoints
+
+### 1. Reproducibility evidence and frozen fixtures
+
+- Add an Issue #170 diagnostic runner that reads the May artifacts, the retained August 7 stores, and isolated current stores without rewriting them.
+- Record taxon universes, trait-input differences, taxonomy-source differences, selected group counts, raw assignment changes, partition changes, and silhouette changes.
+- Freeze compact fixtures containing the relevant target hashes and taxon-level differences rather than copying complete target stores into Git.
+- Validate that current code reproduces the May modern artifact exactly from the August 7 inputs.
+
+Validation gate: the evidence runner must be deterministic, read-only for retained stores, and covered by focused tests for label-invariant partition comparison.
+
+### 2. External-store dependency contract
+
+- Add one reusable function that reads and validates exact target fingerprints from a `{targets}` store.
+- Fail closed for missing stores, missing targets, duplicate metadata rows, errored targets, or absent data hashes.
+- Add an always-checked fingerprint target for `data_traits_classified_corrected` and `data_combined_classification_table_traits` in the continental functional-type segment.
+- Make both imported data targets depend on the corresponding fingerprint so upstream scientific changes invalidate the local spatial graph.
+- Keep the external store read-only and preserve current target payloads.
+
+Validation gate: focused helper tests, manifest inspection for paleo and modern routes, a fixture proving unchanged fingerprints do not invalidate downstream work, and a fixture proving changed fingerprints do invalidate both imported targets.
+
+### 3. Classification provenance and deterministic replay
+
+- Publish an internal provenance target at the classification boundary containing external target hashes, aligned trait-matrix hash, community-taxon hash, clustering settings, selected group count, taxon ordering, classification hash, and runtime/package evidence.
+- Canonically order taxa before distance computation and test permutation-invariant replay from identical scientific inputs.
+- Add fail-closed uniqueness and schema checks for taxon names, classification rows, and provenance keys.
+- Confirm the paleo and modern test pipelines remain restartable and do not rewrite classifications when scientific inputs are unchanged.
+
+Validation gate: focused function tests, exact replay hashes, both test manifests, and clean isolated paleo and modern classification runs.
+
+### 4. Scientific comparison and decision
+
+- Produce taxon-level and group-level comparisons for the May and updated modern classifications, including the seven-versus-eight-group trade-off, cluster sizes, mean silhouettes, changed taxa, changed trait aggregates, and downstream FT occurrence viability.
+- Explain the small paleo silhouette drift using exact input and package/runtime evidence.
+- Record whether the expanded taxonomy is scientifically preferable and whether the seven-group result should replace the May reference.
+- Only after approval, regenerate and publish the accepted classification artifacts with full provenance and update the retained reference fixtures.
+
+Validation gate: explicit scientific approval, independent read-only review, full focused trait tests, affected pipeline smoke tests, architecture validation, and `git diff --check`.
+
+## Risks and controls
+
+| Risk | Control |
+|---|---|
+| External taxonomic services change responses over time | Persist exact target hashes and require intentional refresh evidence at the shared trait-store boundary. |
+| Cluster labels are mistaken for scientific changes | Compare partitions through co-clustering relationships in addition to raw integer labels. |
+| New taxa legitimately alter the dendrogram | Report taxon-universe and trait-input changes separately from deterministic replay. |
+| A cross-store fingerprint causes unnecessary model reruns | Fingerprint only exact imported scientific targets, not timestamps or complete store metadata. |
+| Regenerated files silently become the new baseline | Keep writers out of the diagnostic path until explicit scientific approval. |
+
+## Completion criteria
+
+- The modern drift has a reproducible, evidence-backed explanation.
+- Identical scientific inputs produce identical group selection, assignments, silhouettes, and hashes.
+- Changes to either imported trait-store target invalidate the corresponding local spatial targets.
+- The accepted modern taxon universe and classification have explicit scientific approval and complete provenance.
+- No retained store is rewritten during diagnosis, and no unreviewed classification artifact is published.

--- a/R/03_Supplementary_analyses/Testing/testthat/Data/Traits/Validation/Functional_type_classification/test-evaluate_functional_type_classification_change.R
+++ b/R/03_Supplementary_analyses/Testing/testthat/Data/Traits/Validation/Functional_type_classification/test-evaluate_functional_type_classification_change.R
@@ -1,0 +1,113 @@
+testthat::test_that(
+  "evaluate_functional_type_classification_change() ignores label permutations",
+  {
+    data_reference <-
+      tibble::tibble(
+        taxon_name = base::c("a", "b", "c", "d"),
+        functional_type = base::c(1L, 1L, 2L, 2L),
+        silhouette_width = base::c(0.4, 0.5, 0.6, 0.7)
+      )
+
+    data_candidate <-
+      tibble::tibble(
+        taxon_name = base::c("d", "c", "b", "a"),
+        functional_type = base::c(9L, 9L, 4L, 4L),
+        silhouette_width = base::c(0.7, 0.6, 0.5, 0.4)
+      )
+
+    list_comparison <-
+      evaluate_functional_type_classification_change(
+        data_reference = data_reference,
+        data_candidate = data_candidate
+      )
+
+    data_summary <-
+      purrr::chuck(list_comparison, "data_summary")
+
+    testthat::expect_equal(
+      dplyr::pull(data_summary, raw_assignment_difference_count),
+      4L
+    )
+    testthat::expect_equal(
+      dplyr::pull(data_summary, partition_pair_difference_count),
+      0
+    )
+    testthat::expect_true(
+      dplyr::pull(data_summary, partition_identical)
+    )
+    testthat::expect_equal(
+      dplyr::pull(data_summary, silhouette_difference_count),
+      0L
+    )
+  }
+)
+
+
+testthat::test_that(
+  "evaluate_functional_type_classification_change() detects partition changes",
+  {
+    data_reference <-
+      tibble::tibble(
+        taxon_name = base::c("a", "b", "c", "d"),
+        functional_type = base::c(1L, 1L, 2L, 2L),
+        silhouette_width = base::c(0.4, 0.5, 0.6, 0.7)
+      )
+
+    data_candidate <-
+      tibble::tibble(
+        taxon_name = base::c("a", "b", "c", "d", "e"),
+        functional_type = base::c(1L, 2L, 2L, 2L, 3L),
+        silhouette_width = base::c(0.4, 0.1, 0.6, 0.7, 0.8)
+      )
+
+    list_comparison <-
+      evaluate_functional_type_classification_change(
+        data_reference = data_reference,
+        data_candidate = data_candidate
+      )
+
+    data_summary <-
+      purrr::chuck(list_comparison, "data_summary")
+    data_taxa <-
+      purrr::chuck(list_comparison, "data_taxon_comparison")
+
+    testthat::expect_equal(
+      dplyr::pull(data_summary, added_taxon_count),
+      1L
+    )
+    testthat::expect_equal(
+      dplyr::pull(data_summary, partition_pair_difference_count),
+      3
+    )
+    testthat::expect_false(
+      dplyr::pull(data_summary, partition_identical)
+    )
+    testthat::expect_equal(
+      data_taxa |>
+        dplyr::filter(.data[["taxon_name"]] == "e") |>
+        dplyr::pull("taxon_status"),
+      "added"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "evaluate_functional_type_classification_change() fails on duplicate taxa",
+  {
+    data_duplicate <-
+      tibble::tibble(
+        taxon_name = base::c("a", "a"),
+        functional_type = base::c(1L, 1L),
+        silhouette_width = base::c(0.4, 0.5)
+      )
+
+    testthat::expect_error(
+      evaluate_functional_type_classification_change(
+        data_reference = data_duplicate,
+        data_candidate = data_duplicate
+      ),
+      regexp = "unique"
+    )
+  }
+)

--- a/R/03_Supplementary_analyses/Testing/testthat/Pipeline/Stores/Metadata/test-load_targets_target_by_fingerprint.R
+++ b/R/03_Supplementary_analyses/Testing/testthat/Pipeline/Stores/Metadata/test-load_targets_target_by_fingerprint.R
@@ -1,0 +1,53 @@
+testthat::test_that(
+  "load_targets_target_by_fingerprint() reads the expected target",
+  {
+    data_fingerprint <-
+      tibble::tibble(
+        name = "target_a",
+        data_hash = "hash_a"
+      )
+
+    fake_read <- function(name, store) {
+      base::list(name = name, store = store)
+    }
+
+    list_target <-
+      load_targets_target_by_fingerprint(
+        store_path = "store",
+        target_name = "target_a",
+        data_fingerprint = data_fingerprint,
+        read_fn = fake_read
+      )
+
+    testthat::expect_identical(
+      purrr::chuck(list_target, "name"),
+      "target_a"
+    )
+    testthat::expect_identical(
+      purrr::chuck(list_target, "store"),
+      "store"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_by_fingerprint() rejects mismatched fingerprints",
+  {
+    data_fingerprint <-
+      tibble::tibble(
+        name = "target_b",
+        data_hash = "hash_b"
+      )
+
+    testthat::expect_error(
+      load_targets_target_by_fingerprint(
+        store_path = "store",
+        target_name = "target_a",
+        data_fingerprint = data_fingerprint,
+        read_fn = base::identity
+      ),
+      regexp = "target_a"
+    )
+  }
+)

--- a/R/03_Supplementary_analyses/Testing/testthat/Pipeline/Stores/Metadata/test-load_targets_target_fingerprints.R
+++ b/R/03_Supplementary_analyses/Testing/testthat/Pipeline/Stores/Metadata/test-load_targets_target_fingerprints.R
@@ -1,0 +1,134 @@
+testthat::test_that(
+  "load_targets_target_fingerprints() returns ordered hashes",
+  {
+    fake_meta <- function(fields, complete_only, store) {
+      tibble::tibble(
+        name = base::c("target_b", "target_a"),
+        data = base::c("hash_b", "hash_a"),
+        error = base::c(NA_character_, NA_character_)
+      )
+    }
+
+    data_fingerprints <-
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = base::c("target_b", "target_a"),
+        meta_fn = fake_meta
+      )
+
+    testthat::expect_identical(
+      dplyr::pull(data_fingerprints, "name"),
+      base::c("target_a", "target_b")
+    )
+    testthat::expect_identical(
+      dplyr::pull(data_fingerprints, "data_hash"),
+      base::c("hash_a", "hash_b")
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_fingerprints() fails on missing targets",
+  {
+    fake_meta <- function(fields, complete_only, store) {
+      tibble::tibble(
+        name = "target_a",
+        data = "hash_a",
+        error = NA_character_
+      )
+    }
+
+    testthat::expect_error(
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = base::c("target_a", "target_b"),
+        meta_fn = fake_meta
+      ),
+      regexp = "target_b"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_fingerprints() fails on duplicate metadata",
+  {
+    fake_meta <- function(fields, complete_only, store) {
+      tibble::tibble(
+        name = base::c("target_a", "target_a"),
+        data = base::c("hash_a", "hash_a"),
+        error = base::c(NA_character_, NA_character_)
+      )
+    }
+
+    testthat::expect_error(
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = "target_a",
+        meta_fn = fake_meta
+      ),
+      regexp = "exactly once"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_fingerprints() fails on errored targets",
+  {
+    fake_meta <- function(fields, complete_only, store) {
+      tibble::tibble(
+        name = "target_a",
+        data = "hash_a",
+        error = "failed"
+      )
+    }
+
+    testthat::expect_error(
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = "target_a",
+        meta_fn = fake_meta
+      ),
+      regexp = "errored"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_fingerprints() fails on missing hashes",
+  {
+    fake_meta <- function(fields, complete_only, store) {
+      tibble::tibble(
+        name = "target_a",
+        data = NA_character_,
+        error = NA_character_
+      )
+    }
+
+    testthat::expect_error(
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = "target_a",
+        meta_fn = fake_meta
+      ),
+      regexp = "data hash"
+    )
+  }
+)
+
+
+testthat::test_that(
+  "load_targets_target_fingerprints() validates target names",
+  {
+    testthat::expect_error(
+      load_targets_target_fingerprints(
+        store_path = "store",
+        target_names = base::c("target_a", "target_a")
+      ),
+      regexp = "target_names"
+    )
+  }
+)

--- a/R/Functions/Data/Traits/Validation/Functional_type_classification/evaluate_functional_type_classification_change.R
+++ b/R/Functions/Data/Traits/Validation/Functional_type_classification/evaluate_functional_type_classification_change.R
@@ -1,0 +1,212 @@
+#' @title Evaluate a Functional-Type Classification Change
+#' @description
+#' Compares two functional-type classifications by taxon, raw cluster
+#' labels, label-invariant co-clustering relationships, and silhouette
+#' widths. The partition comparison is invariant to arbitrary integer
+#' relabelling of otherwise identical clusters.
+#' @param data_reference
+#' A data frame with unique `taxon_name` values and columns
+#' `functional_type` and `silhouette_width`.
+#' @param data_candidate
+#' A data frame with the same required columns as `data_reference`.
+#' @return
+#' A named list with `data_summary`, a one-row tibble of comparison
+#' counts, and `data_taxon_comparison`, a taxon-level full join of both
+#' classifications.
+#' @details
+#' Label-invariant partition differences are counted from cluster-size
+#' and contingency-table combinations. This avoids constructing a
+#' quadratic taxon-by-taxon matrix while counting pairs that are in the
+#' same cluster in exactly one classification.
+#' @examples
+#' data_reference <- tibble::tibble(
+#'   taxon_name = c("a", "b", "c"),
+#'   functional_type = c(1L, 1L, 2L),
+#'   silhouette_width = c(0.4, 0.5, 0.6)
+#' )
+#' data_candidate <- tibble::tibble(
+#'   taxon_name = c("a", "b", "c"),
+#'   functional_type = c(2L, 2L, 1L),
+#'   silhouette_width = c(0.4, 0.5, 0.6)
+#' )
+#' evaluate_functional_type_classification_change(
+#'   data_reference,
+#'   data_candidate
+#' )
+#' @export
+evaluate_functional_type_classification_change <- function(
+    data_reference,
+    data_candidate) {
+  vec_required_columns <-
+    base::c(
+      "taxon_name",
+      "functional_type",
+      "silhouette_width"
+    )
+
+  assertthat::assert_that(
+    base::is.data.frame(data_reference),
+    msg = "`data_reference` must be a data frame."
+  )
+  assertthat::assert_that(
+    base::is.data.frame(data_candidate),
+    msg = "`data_candidate` must be a data frame."
+  )
+  assertthat::assert_that(
+    base::all(
+      vec_required_columns %in% base::colnames(data_reference)
+    ),
+    msg = "`data_reference` is missing required columns."
+  )
+  assertthat::assert_that(
+    base::all(
+      vec_required_columns %in% base::colnames(data_candidate)
+    ),
+    msg = "`data_candidate` is missing required columns."
+  )
+  assertthat::assert_that(
+    !base::any(base::is.na(data_reference[["taxon_name"]])) &&
+      !base::any(base::duplicated(data_reference[["taxon_name"]])),
+    msg = "`data_reference$taxon_name` must contain unique values."
+  )
+  assertthat::assert_that(
+    !base::any(base::is.na(data_candidate[["taxon_name"]])) &&
+      !base::any(base::duplicated(data_candidate[["taxon_name"]])),
+    msg = "`data_candidate$taxon_name` must contain unique values."
+  )
+  assertthat::assert_that(
+    !base::any(base::is.na(data_reference[["functional_type"]])) &&
+      !base::any(base::is.na(data_candidate[["functional_type"]])),
+    msg = "`functional_type` values must not be missing."
+  )
+  assertthat::assert_that(
+    base::is.numeric(data_reference[["silhouette_width"]]) &&
+      base::is.numeric(data_candidate[["silhouette_width"]]),
+    msg = "`silhouette_width` values must be numeric."
+  )
+
+  data_reference_selected <-
+    data_reference |>
+    dplyr::select(dplyr::all_of(vec_required_columns)) |>
+    dplyr::rename(
+      functional_type_reference = "functional_type",
+      silhouette_width_reference = "silhouette_width"
+    )
+
+  data_candidate_selected <-
+    data_candidate |>
+    dplyr::select(dplyr::all_of(vec_required_columns)) |>
+    dplyr::rename(
+      functional_type_candidate = "functional_type",
+      silhouette_width_candidate = "silhouette_width"
+    )
+
+  data_taxon_comparison <-
+    dplyr::full_join(
+      data_reference_selected,
+      data_candidate_selected,
+      by = dplyr::join_by(taxon_name)
+    ) |>
+    dplyr::mutate(
+      taxon_status = dplyr::case_when(
+        base::is.na(.data[["functional_type_reference"]]) ~ "added",
+        base::is.na(.data[["functional_type_candidate"]]) ~ "removed",
+        TRUE ~ "shared"
+      ),
+      raw_assignment_changed = dplyr::if_else(
+        .data[["taxon_status"]] == "shared",
+        .data[["functional_type_reference"]] !=
+          .data[["functional_type_candidate"]],
+        NA
+      ),
+      silhouette_delta = .data[["silhouette_width_candidate"]] -
+        .data[["silhouette_width_reference"]]
+    ) |>
+    dplyr::arrange(.data[["taxon_name"]])
+
+  data_shared <-
+    data_taxon_comparison |>
+    dplyr::filter(.data[["taxon_status"]] == "shared")
+
+  reference_same_pair_count <-
+    data_shared |>
+    dplyr::count(.data[["functional_type_reference"]]) |>
+    dplyr::summarise(
+      pair_count = base::sum(.data[["n"]] * (.data[["n"]] - 1) / 2)
+    ) |>
+    dplyr::pull("pair_count")
+
+  candidate_same_pair_count <-
+    data_shared |>
+    dplyr::count(.data[["functional_type_candidate"]]) |>
+    dplyr::summarise(
+      pair_count = base::sum(.data[["n"]] * (.data[["n"]] - 1) / 2)
+    ) |>
+    dplyr::pull("pair_count")
+
+  shared_same_pair_count <-
+    data_shared |>
+    dplyr::count(
+      .data[["functional_type_reference"]],
+      .data[["functional_type_candidate"]]
+    ) |>
+    dplyr::summarise(
+      pair_count = base::sum(.data[["n"]] * (.data[["n"]] - 1) / 2)
+    ) |>
+    dplyr::pull("pair_count")
+
+  partition_pair_difference_count <-
+    reference_same_pair_count + candidate_same_pair_count -
+    2 * shared_same_pair_count
+
+  vec_silhouette_delta <-
+    data_shared |>
+    dplyr::pull("silhouette_delta")
+
+  maximum_absolute_silhouette_delta <-
+    if (
+      base::length(vec_silhouette_delta) == 0L
+    ) {
+      NA_real_
+    } else {
+      base::max(base::abs(vec_silhouette_delta), na.rm = TRUE)
+    }
+
+  data_summary <-
+    tibble::tibble(
+      reference_taxon_count = base::nrow(data_reference_selected),
+      candidate_taxon_count = base::nrow(data_candidate_selected),
+      shared_taxon_count = base::nrow(data_shared),
+      added_taxon_count = base::sum(
+        data_taxon_comparison[["taxon_status"]] == "added"
+      ),
+      removed_taxon_count = base::sum(
+        data_taxon_comparison[["taxon_status"]] == "removed"
+      ),
+      reference_group_count = dplyr::n_distinct(
+        data_reference_selected[["functional_type_reference"]]
+      ),
+      candidate_group_count = dplyr::n_distinct(
+        data_candidate_selected[["functional_type_candidate"]]
+      ),
+      raw_assignment_difference_count = base::sum(
+        data_shared[["raw_assignment_changed"]]
+      ),
+      partition_pair_difference_count = partition_pair_difference_count,
+      partition_identical = partition_pair_difference_count == 0,
+      silhouette_difference_count = base::sum(
+        vec_silhouette_delta != 0,
+        na.rm = TRUE
+      ),
+      maximum_absolute_silhouette_delta =
+        maximum_absolute_silhouette_delta
+    )
+
+  res <-
+    base::list(
+      data_summary = data_summary,
+      data_taxon_comparison = data_taxon_comparison
+    )
+
+  return(res)
+}

--- a/R/Functions/Pipeline/Stores/Metadata/load_targets_target_by_fingerprint.R
+++ b/R/Functions/Pipeline/Stores/Metadata/load_targets_target_by_fingerprint.R
@@ -1,0 +1,86 @@
+#' @title Load a Target Tracked by an External Fingerprint
+#' @description
+#' Loads one target from an external `{targets}` store while requiring
+#' an exact, previously validated fingerprint row for that target. The
+#' explicit fingerprint argument creates a local dependency on external
+#' scientific content instead of depending only on the store path.
+#' @param store_path
+#' A single non-empty character string with the targets store path.
+#' @param target_name
+#' A single non-empty character string naming the target to load.
+#' @param data_fingerprint
+#' A one-row data frame with columns `name` and `data_hash`, as returned
+#' by [load_targets_target_fingerprints()].
+#' @param read_fn
+#' Function used to read the target. Defaults to
+#' [targets::tar_read_raw()].
+#' @return
+#' The target value returned by `read_fn`.
+#' @examples
+#' \dontrun{
+#' data_fingerprint <- load_targets_target_fingerprints(
+#'   store_path = "Data/targets/traits_reference/pipeline_traits_reference",
+#'   target_names = "data_traits_classified_corrected"
+#' )
+#' load_targets_target_by_fingerprint(
+#'   store_path = "Data/targets/traits_reference/pipeline_traits_reference",
+#'   target_name = "data_traits_classified_corrected",
+#'   data_fingerprint = data_fingerprint
+#' )
+#' }
+#' @export
+load_targets_target_by_fingerprint <- function(
+    store_path,
+    target_name,
+    data_fingerprint,
+    read_fn = targets::tar_read_raw) {
+  assertthat::assert_that(
+    base::is.character(store_path) &&
+      base::length(store_path) == 1L &&
+      base::nchar(store_path) > 0L,
+    msg = "`store_path` must be a single non-empty character string."
+  )
+  assertthat::assert_that(
+    base::is.character(target_name) &&
+      base::length(target_name) == 1L &&
+      base::nchar(target_name) > 0L,
+    msg = "`target_name` must be a single non-empty character string."
+  )
+  assertthat::assert_that(
+    base::is.data.frame(data_fingerprint) &&
+      base::identical(
+        base::colnames(data_fingerprint),
+        base::c("name", "data_hash")
+      ) &&
+      base::nrow(data_fingerprint) == 1L,
+    msg = "`data_fingerprint` must be one validated fingerprint row."
+  )
+  assertthat::assert_that(
+    base::identical(
+      data_fingerprint[["name"]][[1L]],
+      target_name
+    ),
+    msg = stringr::str_glue(
+      "`data_fingerprint` does not describe target `{target_name}`."
+    )
+  )
+  assertthat::assert_that(
+    base::is.character(data_fingerprint[["data_hash"]]) &&
+      base::length(data_fingerprint[["data_hash"]]) == 1L &&
+      !base::is.na(data_fingerprint[["data_hash"]]) &&
+      base::nzchar(data_fingerprint[["data_hash"]]),
+    msg = "`data_fingerprint$data_hash` must be non-empty."
+  )
+  assertthat::assert_that(
+    base::is.function(read_fn),
+    msg = "`read_fn` must be a function."
+  )
+
+  res <-
+    read_fn(
+      name = target_name,
+      store = store_path
+    )
+
+  return(res)
+}

--- a/R/Functions/Pipeline/Stores/Metadata/load_targets_target_fingerprints.R
+++ b/R/Functions/Pipeline/Stores/Metadata/load_targets_target_fingerprints.R
@@ -1,0 +1,158 @@
+#' @title Load Target Fingerprints from a Targets Store
+#' @description
+#' Reads and validates content hashes for exact target names in an
+#' external `{targets}` store. The function fails closed when metadata
+#' are unavailable, incomplete, duplicated, errored, or unhashed.
+#' @param store_path
+#' A single non-empty character string with the targets store path.
+#' @param target_names
+#' A character vector of unique, non-empty target names.
+#' @param meta_fn
+#' Function used to read metadata. Defaults to [targets::tar_meta()].
+#' @return
+#' A tibble with `name` and `data_hash`, ordered by `name`.
+#' @examples
+#' \dontrun{
+#' load_targets_target_fingerprints(
+#'   store_path = "Data/targets/traits_reference/pipeline_traits_reference",
+#'   target_names = c(
+#'     "data_traits_classified_corrected",
+#'     "data_combined_classification_table_traits"
+#'   )
+#' )
+#' }
+#' @export
+load_targets_target_fingerprints <- function(
+    store_path,
+    target_names,
+    meta_fn = targets::tar_meta) {
+  assertthat::assert_that(
+    base::is.character(store_path) &&
+      base::length(store_path) == 1L &&
+      base::nchar(store_path) > 0L,
+    msg = "`store_path` must be a single non-empty character string."
+  )
+  assertthat::assert_that(
+    base::is.character(target_names) &&
+      base::length(target_names) > 0L &&
+      base::all(!base::is.na(target_names)) &&
+      base::all(base::nzchar(target_names)) &&
+      !base::any(base::duplicated(target_names)),
+    msg = "`target_names` must contain unique non-empty strings."
+  )
+  assertthat::assert_that(
+    base::is.function(meta_fn),
+    msg = "`meta_fn` must be a function."
+  )
+
+  data_metadata <-
+    base::tryCatch(
+      base::suppressWarnings(
+        meta_fn(
+          fields = base::c("name", "data", "error"),
+          complete_only = FALSE,
+          store = store_path
+        )
+      ),
+      error = function(condition) {
+        cli::cli_abort(
+          base::c(
+            "x" = "Could not read external targets-store metadata.",
+            "i" = base::conditionMessage(condition)
+          )
+        )
+      }
+    )
+
+  vec_required_columns <-
+    base::c("name", "data", "error")
+
+  if (
+    !base::is.data.frame(data_metadata) ||
+      !base::all(
+        vec_required_columns %in% base::colnames(data_metadata)
+      )
+  ) {
+    cli::cli_abort(
+      "External targets-store metadata are malformed."
+    )
+  }
+
+  data_selected <-
+    data_metadata |>
+    dplyr::filter(.data[["name"]] %in% target_names)
+
+  data_counts <-
+    data_selected |>
+    dplyr::count(.data[["name"]], name = "metadata_row_count")
+
+  vec_missing_targets <-
+    base::setdiff(
+      target_names,
+      dplyr::pull(data_counts, "name")
+    )
+
+  if (
+    base::length(vec_missing_targets) > 0L
+  ) {
+    cli::cli_abort(
+      base::c(
+        "x" = "Required external targets are missing.",
+        "i" = stringr::str_c(
+          vec_missing_targets,
+          collapse = ", "
+        )
+      )
+    )
+  }
+
+  data_duplicate_targets <-
+    data_counts |>
+    dplyr::filter(.data[["metadata_row_count"]] != 1L)
+
+  if (
+    base::nrow(data_duplicate_targets) > 0L
+  ) {
+    cli::cli_abort(
+      "Each requested target must occur exactly once in metadata."
+    )
+  }
+
+  data_errored_targets <-
+    data_selected |>
+    dplyr::filter(
+      !base::is.na(.data[["error"]]) &
+        base::nzchar(.data[["error"]])
+    )
+
+  if (
+    base::nrow(data_errored_targets) > 0L
+  ) {
+    cli::cli_abort(
+      "Requested external targets include errored targets."
+    )
+  }
+
+  data_missing_hashes <-
+    data_selected |>
+    dplyr::filter(
+      base::is.na(.data[["data"]]) |
+        !base::nzchar(.data[["data"]])
+    )
+
+  if (
+    base::nrow(data_missing_hashes) > 0L
+  ) {
+    cli::cli_abort(
+      "Every requested external target must have a data hash."
+    )
+  }
+
+  data_fingerprints <-
+    data_selected |>
+    dplyr::select(dplyr::all_of(base::c("name", "data"))) |>
+    dplyr::rename(data_hash = "data") |>
+    dplyr::arrange(.data[["name"]])
+
+  return(data_fingerprints)
+}

--- a/R/Pipelines/_pipes/_helpers/make_pipe_segment_ft_classification_continental.R
+++ b/R/Pipelines/_pipes/_helpers/make_pipe_segment_ft_classification_continental.R
@@ -275,13 +275,38 @@ make_pipe_segment_ft_classification_continental <- function(
 
       targets::tar_target(
         description = stringr::str_glue(
+          "Fingerprint classified corrected traits in the shared store"
+        ),
+        name = data_traits_classified_corrected_fingerprint,
+        command = load_targets_target_fingerprints(
+          store_path = path_traits_reference_store,
+          target_names = "data_traits_classified_corrected"
+        ),
+        cue = targets::tar_cue(mode = "always")
+      ),
+
+      targets::tar_target(
+        description = stringr::str_glue(
+          "Fingerprint trait taxonomy in the shared store"
+        ),
+        name = data_trait_taxonomy_fingerprint,
+        command = load_targets_target_fingerprints(
+          store_path = path_traits_reference_store,
+          target_names = "data_combined_classification_table_traits"
+        ),
+        cue = targets::tar_cue(mode = "always")
+      ),
+
+      targets::tar_target(
+        description = stringr::str_glue(
           "Load classified corrected traits from ",
           "shared traits pipeline store"
         ),
         name = data_traits_for_functional_type_classification,
-        command = targets::tar_read(
-          data_traits_classified_corrected,
-          store = path_traits_reference_store
+        command = load_targets_target_by_fingerprint(
+          store_path = path_traits_reference_store,
+          target_name = "data_traits_classified_corrected",
+          data_fingerprint = data_traits_classified_corrected_fingerprint
         )
       ),
       targets::tar_target(
@@ -290,9 +315,10 @@ make_pipe_segment_ft_classification_continental <- function(
           "shared traits pipeline store"
         ),
         name = data_classification_table_for_functional_types,
-        command = targets::tar_read(
-          data_combined_classification_table_traits,
-          store = path_traits_reference_store
+        command = load_targets_target_by_fingerprint(
+          store_path = path_traits_reference_store,
+          target_name = "data_combined_classification_table_traits",
+          data_fingerprint = data_trait_taxonomy_fingerprint
         )
       ),
 


### PR DESCRIPTION
## Summary

- Add strict scientific-content fingerprints for targets imported from the shared trait store.
- Make corrected trait records and trait taxonomy invalidate their corresponding continental functional-type imports independently.
- Add a label-invariant comparator that separates raw cluster-label changes from genuine partition changes.
- Document the reproducibility investigation, the isolated root cause, and the boundary between this architecture correction and the pending scientific decision.

## Why

The continental functional-type pipelines imported shared trait targets with `tar_read()` while tracking only the external store path. When the upstream trait taxonomy changed, the local spatial stores could therefore retain stale imported payloads until an unrelated command change invalidated them.

The investigation shows that the regenerated classification drift is deterministic and input-driven rather than stochastic. The retained modern inputs reproduce the existing 563-taxon, eight-group artifact exactly under current code. The refreshed taxonomy expands the modern universe to 565 taxa and selects seven groups, producing 9,330 changed taxon-pair co-clustering relationships. Paleo assignments remain unchanged, with only small silhouette differences caused by the changed `Ericales` trait aggregate.

## Dependency contract

- `load_targets_target_fingerprints()` reads exact external target hashes and fails closed for missing stores, missing or duplicate metadata rows, errored targets, and absent data hashes.
- `load_targets_target_by_fingerprint()` verifies the requested fingerprint before returning the external payload.
- Separate always-checked fingerprint targets track corrected traits and trait taxonomy, so either scientific input invalidates only its corresponding local import.
- External stores remain read-only, and unchanged fingerprints preserve restartability without reloading unchanged payloads.

## Scientific scope

No regenerated functional-type classification artifact is accepted, published, or committed here. Scientific review is still required to decide whether the updated seven-group modern result should replace the retained eight-group reference. The remaining provenance, comparison, and approval work stays tracked in Issue #170.

## Validation

- All 19 focused tests for fingerprint loading, verified external reads, and label-invariant classification comparison passed.
- Changed R sources parsed successfully.
- Paleo and modern continental manifests built successfully with 276 and 264 targets, respectively.
- Live boundary targets completed without errors in both retained stores.
- A same-code modern rerun executed only the three lightweight fingerprint checks and skipped both unchanged imported payloads.
- `git diff --check origin/main...HEAD` passed.

## Relationships

- Part of #170
- Follow-up to #169
